### PR TITLE
Email refactoring 2

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -272,22 +272,14 @@ def prepare_to_notify(doc, print_html=None, print_format=None, attachments=None)
 				doc.attachments.append(a)
 
 def set_incoming_outgoing_accounts(doc):
-	doc.incoming_email_account = doc.outgoing_email_account = None
+	from frappe.email.doctype.email_account.email_account import EmailAccount
 
-	if not doc.incoming_email_account and doc.sender:
-		doc.incoming_email_account = frappe.db.get_value("Email Account",
-			{"email_id": doc.sender, "enable_incoming": 1}, "email_id")
+	incoming_email_account = EmailAccount.find_incoming(
+		match_by_email=doc.sender, match_by_doctype=doc.doctype)
+	doc.incoming_email_account = incoming_email_account.email_id if incoming_email_account else None
 
-	if not doc.incoming_email_account and doc.reference_doctype:
-		doc.incoming_email_account = frappe.db.get_value("Email Account",
-			{"append_to": doc.reference_doctype, }, "email_id")
-
-	if not doc.incoming_email_account:
-		doc.incoming_email_account = frappe.db.get_value("Email Account",
-			{"default_incoming": 1, "enable_incoming": 1},  "email_id")
-
-	doc.outgoing_email_account = frappe.email.smtp.get_outgoing_email_account(raise_exception_not_set=False,
-		append_to=doc.doctype, sender=doc.sender)
+	doc.outgoing_email_account = EmailAccount.find_outgoing(
+		match_by_email=doc.sender, match_by_doctype=doc.doctype)
 
 	if doc.sent_or_received == "Sent":
 		doc.db_set("email_account", doc.outgoing_email_account.name)

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -8,9 +8,12 @@ import re
 import json
 import socket
 import time
+import functools
+
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import validate_email_address, cint, cstr, get_datetime, DATE_FORMAT, strip, comma_or, sanitize_html, add_days
+from frappe.utils import (validate_email_address, cint, cstr, get_datetime,
+	DATE_FORMAT, strip, comma_or, sanitize_html, add_days, parse_addr)
 from frappe.utils.user import is_system_user
 from frappe.utils.jinja import render_template
 from frappe.email.smtp import SMTPServer
@@ -21,9 +24,11 @@ from datetime import datetime, timedelta
 from frappe.desk.form import assign_to
 from frappe.utils.user import get_system_managers
 from frappe.utils.background_jobs import enqueue, get_jobs
-from frappe.core.doctype.communication.email import set_incoming_outgoing_accounts
 from frappe.utils.html_utils import clean_email_html
+from frappe.utils.error import raise_error_on_no_output
 from frappe.email.utils import get_port
+
+OUTGOING_EMAIL_ACCOUNT_MISSING = _("Please setup default Email Account from Setup > Email > Email Account")
 
 class SentEmailInInbox(Exception):
 	pass
@@ -31,7 +36,28 @@ class SentEmailInInbox(Exception):
 class InvalidEmailCredentials(frappe.ValidationError):
 	pass
 
+def cache_email_account(cache_name):
+	def decorator_cache_email_account(func):
+		@functools.wraps(func)
+		def wrapper_cache_email_account(*args, **kwargs):
+			if not hasattr(frappe.local, cache_name):
+				setattr(frappe.local, cache_name, {})
+
+			cached_accounts = getattr(frappe.local, cache_name)
+			match_by = list(kwargs.values()) + ['default']
+			matched_accounts = list(filter(None, [cached_accounts.get(key) for key in match_by]))
+			if matched_accounts:
+				return matched_accounts[0]
+
+			matched_accounts = func(*args, **kwargs)
+			cached_accounts.update(matched_accounts or {})
+			return matched_accounts and list(matched_accounts.values())[0]
+		return wrapper_cache_email_account
+	return decorator_cache_email_account
+
 class EmailAccount(Document):
+	DOCTYPE = 'Email Account'
+
 	def autoname(self):
 		"""Set name as `email_account_name` or make title from Email Address."""
 		if not self.email_account_name:
@@ -249,6 +275,10 @@ class EmailAccount(Document):
 			else:
 				raise
 
+	# @property
+	# def password(self):
+	# 	return self.get_password(raise_exception=False) or getattr(self, '_password', None)
+
 	@classmethod
 	def throw_invalid_credentials_exception(cls):
 		frappe.throw(
@@ -256,6 +286,102 @@ class EmailAccount(Document):
 			exc=InvalidEmailCredentials,
 			title=_("Invalid Credentials")
 		)
+
+	@classmethod
+	def from_record(cls, record):
+		email_account = frappe.new_doc(cls.DOCTYPE)
+		email_account.update(record)
+		return email_account
+
+	@classmethod
+	def find(cls, name):
+		return frappe.get_doc(cls.DOCTYPE, name)
+
+	@classmethod
+	def find_one_by_filters(cls, **kwargs):
+		name = frappe.db.get_value(cls.DOCTYPE, kwargs)
+		return cls.find(name) if name else None
+
+	@classmethod
+	def find_from_config(cls):
+		config = cls.get_account_details_from_site_config()
+		return cls.from_record(config) if config else None
+
+	@classmethod
+	@raise_error_on_no_output(
+		error_message = OUTGOING_EMAIL_ACCOUNT_MISSING, error_type=frappe.OutgoingEmailError)
+	@cache_email_account('outgoing_email_account')
+	def find_outgoing(cls, match_by_email=None, match_by_doctype=None, _raise_error=False):
+		"""Find the outgoing Email account to use.
+
+		:param match_by_email: Find account using emailID
+		:param match_by_doctype: Find account by matching `Append To` doctype
+		:param _raise_error: This is used by raise_error_on_no_output decorator to raise error.
+		"""
+		if match_by_email:
+			match_by_email = parse_addr(match_by_email)[1]
+			doc = cls.find_one_by_filters(enable_outgoing=1, email_id=match_by_email)
+			if doc: return {match_by_email: doc}
+
+		if match_by_doctype:
+			doc = cls.find_one_by_filters(enable_outgoing=1, enable_incoming=1, append_to=match_by_doctype)
+			if doc: return {match_by_doctype: doc}
+
+		doc = cls.find_default_outgoing()
+		if doc:	return {'default': doc}
+
+	@classmethod
+	def find_default_outgoing(cls):
+		""" Find default outgoing account.
+		"""
+		doc = cls.find_one_by_filters(enable_outgoing=1, default_outgoing=1)
+		return doc or cls.find_from_config()
+
+	@classmethod
+	def find_incoming(cls, match_by_email=None, match_by_doctype=None):
+		"""Find the incoming Email account to use.
+		:param match_by_email: Find account using emailID
+		:param match_by_doctype: Find account by matching `Append To` doctype
+		"""
+		doc = cls.find_one_by_filters(enable_incoming=1, email_id=match_by_email)
+		if doc: return doc
+
+		doc = cls.find_one_by_filters(append_to=match_by_doctype)
+		if doc: return doc
+
+		doc = cls.find_default_incoming()
+		return doc
+
+	@classmethod
+	def find_default_incoming(cls):
+		doc = cls.find_one_by_filters(enable_incoming=1, default_incoming=1)
+		return doc
+
+	@classmethod
+	def get_account_details_from_site_config(cls):
+		if not frappe.conf.get("mail_server"): return {}
+
+		field_to_conf_name_map = {
+			'smtp_server': { 'conf_names': ('mail_server',) },
+			'smtp_port': { 'conf_names': ('mail_port',) },
+			'use_tls': { 'conf_names': ('use_tls', 'mail_login') },
+			'login_id': { 'conf_names': ('mail_login',) },
+			'email_id': { 'conf_names': ('auto_email_id', 'mail_login'), 'default': 'notifications@example.com' },
+			'password': { 'conf_names': ('mail_password',) },
+			'always_use_account_email_id_as_sender':
+				{ 'conf_names': ('always_use_account_email_id_as_sender',), 'default': 0 },
+			'always_use_account_name_as_sender_name':
+				{ 'conf_names': ('always_use_account_name_as_sender_name',), 'default': 0 },
+			'name': { 'conf_names': ('email_sender_name',), 'default': 'Frappe' },
+			'from_site_config': { 'default': True }
+		}
+
+		account_details = {}
+		for doc_field_name, d in field_to_conf_name_map.items():
+			conf_names, default = d.get('conf_names') or [], d.get('default')
+			value = [frappe.conf.get(k) for k in conf_names if frappe.conf.get(k)]
+			account_details[doc_field_name] = (value and value[0]) or default
+		return account_details
 
 	def handle_incoming_connect_error(self, description):
 		if test_internet():
@@ -642,6 +768,8 @@ class EmailAccount(Document):
 
 	def send_auto_reply(self, communication, email):
 		"""Send auto reply if set."""
+		from frappe.core.doctype.communication.email import set_incoming_outgoing_accounts
+
 		if self.enable_auto_reply:
 			set_incoming_outgoing_accounts(communication)
 
@@ -755,6 +883,7 @@ class EmailAccount(Document):
 				email_server.imap.append("Sent", "\\Seen", imaplib.Time2Internaldate(time.time()), message.encode())
 			except Exception:
 				frappe.log_error()
+
 
 @frappe.whitelist()
 def get_append_to(doctype=None, txt=None, searchfield=None, start=None, page_len=None, filters=None):

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -383,6 +383,10 @@ class EmailAccount(Document):
 			account_details[doc_field_name] = (value and value[0]) or default
 		return account_details
 
+	def smtp_conn(self):
+		# TODO: FixMe
+		return SMTPServer()
+
 	def handle_incoming_connect_error(self, description):
 		if test_internet():
 			if self.get_failed_attempts_count() > 2:

--- a/frappe/email/doctype/email_queue/email_queue.json
+++ b/frappe/email/doctype/email_queue/email_queue.json
@@ -24,7 +24,8 @@
   "unsubscribe_method",
   "expose_recipients",
   "attachments",
-  "retry"
+  "retry",
+  "email_account"
  ],
  "fields": [
   {
@@ -139,13 +140,19 @@
    "fieldtype": "Int",
    "label": "Retry",
    "read_only": 1
+  },
+  {
+   "fieldname": "email_account",
+   "fieldtype": "Link",
+   "label": "Email Account",
+   "options": "Email Account"
   }
  ],
  "icon": "fa fa-envelope",
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2020-07-17 15:58:15.369419",
+ "modified": "2021-04-29 06:33:25.191729",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Queue",

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -3,14 +3,25 @@
 # For license information, please see license.txt
 
 from __future__ import unicode_literals
+
+import json
+
+from rq.timeouts import JobTimeoutException
+import smtplib, quopri
+from email.parser import Parser
+
 import frappe
-from frappe import _
+from frappe import _, safe_encode
 from frappe.model.document import Document
-from frappe.email.queue import send_one
+from frappe.email.queue import get_unsubcribed_url
+from frappe.email.email_body import add_attachment
 from frappe.utils import now_datetime
+from email.policy import SMTPUTF8
 
-
+MAX_RETRY_COUNT = 3
 class EmailQueue(Document):
+	DOCTYPE = 'Email Queue'
+
 	def set_recipients(self, recipients):
 		self.set("recipients", [])
 		for r in recipients:
@@ -30,6 +41,192 @@ class EmailQueue(Document):
 		duplicate.set_recipients(recipients)
 		return duplicate
 
+	@classmethod
+	def find(cls, name):
+		return frappe.get_doc(cls.DOCTYPE, name)
+
+	def update_db(self, auto_commit=False, **kwargs):
+		frappe.db.set_value(self.DOCTYPE, self.name, kwargs)
+		if auto_commit:
+			frappe.db.commit()
+
+	@property
+	def cc(self):
+		return self.show_as_cc.split(",")
+
+	@property
+	def to(self):
+		return [r.recipient for r in self.recipients if r.recipient not in self.cc]
+
+	@property
+	def attachments_list(self):
+		return json.loads(self.attachments) if self.attachments else []
+
+	# @classmethod
+	# def new(cls, doc):
+	# 	pass
+
+	def email_account_doc(self):
+		if self.email_account: #TODO: Make email account mandatory
+			return frappe.get_doc('Email Account', self.email_account)
+
+	def is_sent(self):
+		# status Sending ??
+		return self.status not in ['Not Sent','Partially Sent']
+
+	def can_send_now(self, force_send=False):
+		if frappe.are_emails_muted() or self.is_sent():
+			return False
+
+		hold_queue = (cint(frappe.defaults.get_defaults().get("hold_queue"))==1)
+		if hold_queue or frappe.flags.in_test:
+			return False
+
+		if (not force_send) and self.send_after and self.send_after < now_datetime():
+			return False
+
+		return True
+
+	def send(self, force_send=False):
+		""" Send emails and respects the send_after attribute.
+		Use force_send flag to ignore the send_after.
+		"""
+		if not self.can_send_now(force_send):
+			return
+
+		with SendMailContext(self) as ctx:
+			for recipient in self.recipients:
+				message = ctx.build_message(recipient)
+				ctx.smtp_server.sendmail(recipient.recipient, self.sender, message)
+				ctx.add_to_sent_list(recipient.recipient)
+
+class SendMailContext:
+	def __init__(self, queue_doc: Document):
+		self.queue_doc = queue_doc
+		self.email_account_doc = queue_doc.email_account_doc()
+		self.smtp_conn = self.email_account_doc.smtp_conn()
+		self.sent_to = []
+
+	def __enter__(self):
+		self.queue_doc.update_db(status='Sending', auto_commit=True)
+		return self
+
+	def __exit__(self, exc_type, exc_val, exc_tb):
+		#TODO: Log error or raise based on request type
+		# Close SMTP connection
+		# Do rollback?
+
+		exceptions = [
+			smtplib.SMTPServerDisconnected,
+			smtplib.SMTPAuthenticationError,
+			smtplib.SMTPRecipientsRefused,
+			smtplib.SMTPConnectError,
+			smtplib.SMTPHeloError,
+			JobTimeoutException
+		]
+		if exc_type in exceptions:
+			email_status = (self.sent_to and 'Partially Sent') or 'Not Sent'
+			self.queue_doc.update_db(status = email_status, auto_commit = True)
+			return True
+
+		if exc_type:
+			if self.queue_doc.retry < MAX_RETRY_COUNT:
+				update_fields = { 'status': 'Not Sent', 'retry': self.queue_doc.retry+1 }
+			else:
+				update_fields = { 'status': (self.sent_to and 'Partially Errored') or 'Error' }
+			self.queue_doc.update_db(**update_fields, auto_commit = True)
+
+	def add_to_sent_list(self, email):
+		self.sent_to.append(email)
+
+	def get_message_object(self, message):
+		return Parser(policy=SMTPUTF8).parsestr(message)
+
+	def message_placeholder(self, placeholder_key):
+		map = {
+			'tracker': '<!--email open check-->',
+			'unsubscribe_url': '<!--unsubscribe url-->',
+			'cc': '<!--cc message-->',
+			'recipient': '<!--recipient-->',
+		}
+		return map.get(placeholder_key)
+
+	def build_message(self, recipient):
+		"""Build message specific to the recipient.
+		"""
+		message = self.queue_doc.message
+		message = message.replace(self.message_placeholder('tracker'), self.get_tracker_str())
+		message = message.replace(self.message_placeholder('unsubscribe_url'),
+			self.get_unsubscribe_str(recipient.recipient))
+		message = message.replace(self.message_placeholder('cc'), self.get_receivers_str())
+		message = message.replace(self.message_placeholder('recipient'),
+			self.get_receipient_str(recipient.recipient))
+		message = self.include_attachments(message)
+		return message
+
+	def get_tracker_str(self):
+		tracker_url_html = \
+			'<img src="https://{}/api/method/frappe.core.doctype.communication.email.mark_email_as_seen?name={}"/>'
+
+		message = ''
+		if frappe.conf.use_ssl and self.queue_doc.track_email_status:
+			message = quopri.encodestring(
+				tracker_url_html.format(frappe.local.site, self.queue_doc.communication).encode()
+			).decode()
+		return message
+
+	def get_unsubscribe_str(self, recipient_email):
+		unsubscribe_url = ''
+		if self.queue_doc.add_unsubscribe_link and self.queue_doc.reference_doctype:
+			doctype, doc_name = self.queue_doc.reference_doctype, self.queue_doc.reference_name
+			unsubscribe_url = get_unsubcribed_url(doctype, doc_name, recipient_email,
+				self.queue_doc.unsubscribe_method, self.queue_doc.unsubscribe_param)
+
+		return quopri.encodestring(unsubscribe_url.encode()).decode()
+
+	def get_receivers_str(self):
+		message = ''
+		if self.queue_doc.expose_recipients == "footer":
+			to_str =  ', '.join(self.queue_doc.to)
+			cc_str = ', '.join(self.queue_doc.cc)
+			message = f"This email was sent to {to_str}"
+			message = message + f" and copied to {cc_str}" if cc_str else message
+		return message
+
+	def get_receipient_str(self, recipient_email):
+		message = ''
+		if self.queue_doc.expose_recipients != "header":
+			message = recipient_email
+		return message
+
+	def include_attachments(self, message):
+		# TODO: understand and clean
+		message_obj = self.get_message_object(message)
+		attachments = self.queue_doc.attachments_list
+
+		for attachment in attachments:
+			if attachment.get('fcontent'): continue
+
+			fid = attachment.get("fid")
+			if fid:
+				_file = frappe.get_doc("File", fid)
+				fcontent = _file.get_content()
+				attachment.update({
+					'fname': _file.file_name,
+					'fcontent': fcontent,
+					'parent': message_obj
+				})
+				attachment.pop("fid", None)
+				add_attachment(**attachment)
+
+			elif attachment.get("print_format_attachment") == 1:
+				attachment.pop("print_format_attachment", None)
+				print_format_file = frappe.attach_print(**attachment)
+				print_format_file.update({"parent": message_obj})
+				add_attachment(**print_format_file)
+
+		return safe_encode(message_obj.as_string())
+
 @frappe.whitelist()
 def retry_sending(name):
 	doc = frappe.get_doc("Email Queue", name)
@@ -42,7 +239,9 @@ def retry_sending(name):
 
 @frappe.whitelist()
 def send_now(name):
-	send_one(name, now=True)
+	record = EmailQueue.find(name)
+	if record:
+		record.send(force_send = True)
 
 def on_doctype_update():
 	"""Add index in `tabCommunication` for `(reference_doctype, reference_name)`"""

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 import frappe, re, os
 from frappe.utils.pdf import get_pdf
-from frappe.email.smtp import get_outgoing_email_account
+from frappe.email.doctype.email_account.email_account import EmailAccount
 from frappe.utils import (get_url, scrub_urls, strip, expand_relative_urls, cint,
 	split_emails, to_markdown, markdown, random_string, parse_addr)
 import email.utils
@@ -75,7 +75,8 @@ class EMail:
 		self.bcc = bcc or []
 		self.html_set = False
 
-		self.email_account = email_account or get_outgoing_email_account(sender=sender)
+		self.email_account = email_account or \
+			EmailAccount.find_outgoing(match_by_email=sender, _raise_error=True)
 
 	def set_html(self, message, text_content = None, footer=None, print_html=None,
 		formatted=None, inline_images=None, header=None):
@@ -249,8 +250,8 @@ class EMail:
 
 def get_formatted_html(subject, message, footer=None, print_html=None,
 		email_account=None, header=None, unsubscribe_link=None, sender=None, with_container=False):
-	if not email_account:
-		email_account = get_outgoing_email_account(False, sender=sender)
+
+	email_account = email_account or EmailAccount.find_outgoing(match_by_email=sender)
 
 	signature = None
 	if "<!-- signature-included -->" not in message:

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -173,19 +173,19 @@ def add(recipients, sender, subject, **kwargs):
 			if not email_queue:
 				email_queue = get_email_queue([r], sender, subject, **kwargs)
 				if kwargs.get('now'):
-					send_one(email_queue.name, now=True)
+					email_queue.send(force_send=True)
 			else:
 				duplicate = email_queue.get_duplicate([r])
 				duplicate.insert(ignore_permissions=True)
 
 				if kwargs.get('now'):
-					send_one(duplicate.name, now=True)
+					duplicate.send(force_send=True)
 
 			frappe.db.commit()
 	else:
 		email_queue = get_email_queue(recipients, sender, subject, **kwargs)
 		if kwargs.get('now'):
-			send_one(email_queue.name, now=True)
+			email_queue.send(force_send=True)
 
 def get_email_queue(recipients, sender, subject, **kwargs):
 	'''Make Email Queue object'''
@@ -353,7 +353,11 @@ def flush(from_test=False):
 				smtpserver_dict[email.sender] = smtpserver
 
 			if from_test:
-				send_one(email.name, smtpserver, auto_commit)
+				# TEST ME and FIX
+				# send_one(email.name, smtpserver, auto_commit)
+				record = EmailQueue.find(name)
+				if record:
+					record.send(force_send = True)
 			else:
 				send_one_args = {
 					'email': email.name,
@@ -380,213 +384,6 @@ def get_queue():
 		order
 			by priority desc, creation asc
 		limit 500''', { 'now': now_datetime() }, as_dict=True)
-
-
-def send_one(email, smtpserver=None, auto_commit=True, now=False):
-	'''Send Email Queue with given smtpserver'''
-
-	email = frappe.db.sql('''select
-			name, status, communication, message, sender, reference_doctype,
-			reference_name, unsubscribe_param, unsubscribe_method, expose_recipients,
-			show_as_cc, add_unsubscribe_link, attachments, retry
-		from
-			`tabEmail Queue`
-		where
-			name=%s
-		for update''', email, as_dict=True)
-
-	if len(email):
-		email = email[0]
-	else:
-		return
-
-	recipients_list = frappe.db.sql('''select name, recipient, status from
-		`tabEmail Queue Recipient` where parent=%s''', email.name, as_dict=1)
-
-	if frappe.are_emails_muted():
-		frappe.msgprint(_("Emails are muted"))
-		return
-
-	if cint(frappe.defaults.get_defaults().get("hold_queue"))==1 :
-		return
-
-	if email.status not in ('Not Sent','Partially Sent') :
-		# rollback to release lock and return
-		frappe.db.rollback()
-		return
-
-	frappe.db.sql("""update `tabEmail Queue` set status='Sending', modified=%s where name=%s""",
-		(now_datetime(), email.name), auto_commit=auto_commit)
-
-	if email.communication:
-		frappe.get_doc('Communication', email.communication).set_delivery_status(commit=auto_commit)
-
-	email_sent_to_any_recipient = None
-
-	try:
-		message = None
-
-		if not frappe.flags.in_test:
-			if not smtpserver:
-				smtpserver = SMTPServer()
-
-			# to avoid always using default email account for outgoing
-			if getattr(frappe.local, "outgoing_email_account", None):
-				frappe.local.outgoing_email_account = {}
-
-			smtpserver.setup_email_account(email.reference_doctype, sender=email.sender)
-
-		for recipient in recipients_list:
-			if recipient.status != "Not Sent":
-				continue
-
-			message = prepare_message(email, recipient.recipient, recipients_list)
-			if not frappe.flags.in_test:
-				smtpserver.sess.sendmail(email.sender, recipient.recipient, message)
-
-			recipient.status = "Sent"
-			frappe.db.sql("""update `tabEmail Queue Recipient` set status='Sent', modified=%s where name=%s""",
-				(now_datetime(), recipient.name), auto_commit=auto_commit)
-
-		email_sent_to_any_recipient = any("Sent" == s.status for s in recipients_list)
-
-		#if all are sent set status
-		if email_sent_to_any_recipient:
-			frappe.db.sql("""update `tabEmail Queue` set status='Sent', modified=%s where name=%s""",
-				(now_datetime(), email.name), auto_commit=auto_commit)
-		else:
-			frappe.db.sql("""update `tabEmail Queue` set status='Error', error=%s
-				where name=%s""", ("No recipients to send to", email.name), auto_commit=auto_commit)
-		if frappe.flags.in_test:
-			frappe.flags.sent_mail = message
-			return
-		if email.communication:
-			frappe.get_doc('Communication', email.communication).set_delivery_status(commit=auto_commit)
-
-		if smtpserver.append_emails_to_sent_folder and email_sent_to_any_recipient:
-			smtpserver.email_account.append_email_to_sent_folder(message)
-
-	except (smtplib.SMTPServerDisconnected,
-			smtplib.SMTPConnectError,
-			smtplib.SMTPHeloError,
-			smtplib.SMTPAuthenticationError,
-			smtplib.SMTPRecipientsRefused,
-			JobTimeoutException):
-
-		# bad connection/timeout, retry later
-
-		if email_sent_to_any_recipient:
-			frappe.db.sql("""update `tabEmail Queue` set status='Partially Sent', modified=%s where name=%s""",
-				(now_datetime(), email.name), auto_commit=auto_commit)
-		else:
-			frappe.db.sql("""update `tabEmail Queue` set status='Not Sent', modified=%s where name=%s""",
-				(now_datetime(), email.name), auto_commit=auto_commit)
-
-		if email.communication:
-			frappe.get_doc('Communication', email.communication).set_delivery_status(commit=auto_commit)
-
-		# no need to attempt further
-		return
-
-	except Exception as e:
-		frappe.db.rollback()
-
-		if email.retry < 3:
-			frappe.db.sql("""update `tabEmail Queue` set status='Not Sent', modified=%s, retry=retry+1 where name=%s""",
-				(now_datetime(), email.name), auto_commit=auto_commit)
-		else:
-			if email_sent_to_any_recipient:
-				frappe.db.sql("""update `tabEmail Queue` set status='Partially Errored', error=%s where name=%s""",
-					(text_type(e), email.name), auto_commit=auto_commit)
-			else:
-				frappe.db.sql("""update `tabEmail Queue` set status='Error', error=%s
-					where name=%s""", (text_type(e), email.name), auto_commit=auto_commit)
-
-		if email.communication:
-			frappe.get_doc('Communication', email.communication).set_delivery_status(commit=auto_commit)
-
-		if now:
-			print(frappe.get_traceback())
-			raise e
-
-		else:
-			# log to Error Log
-			frappe.log_error('frappe.email.queue.flush')
-
-def prepare_message(email, recipient, recipients_list):
-	message = email.message
-	if not message:
-		return ""
-
-	# Parse "Email Account" from "Email Sender"
-	email_account = EmailAccount.find_outgoing(match_by_email=email.sender)
-	if frappe.conf.use_ssl and email_account.track_email_status:
-		# Using SSL => Publically available domain => Email Read Reciept Possible
-		message = message.replace("<!--email open check-->", quopri.encodestring('<img src="https://{}/api/method/frappe.core.doctype.communication.email.mark_email_as_seen?name={}"/>'.format(frappe.local.site, email.communication).encode()).decode())
-	else:
-		# No SSL => No Email Read Reciept
-		message = message.replace("<!--email open check-->", quopri.encodestring("".encode()).decode())
-
-	if email.add_unsubscribe_link and email.reference_doctype: # is missing the check for unsubscribe message but will not add as there will be no unsubscribe url
-		unsubscribe_url = get_unsubcribed_url(email.reference_doctype, email.reference_name, recipient,
-		email.unsubscribe_method, email.unsubscribe_params)
-		message = message.replace("<!--unsubscribe url-->", quopri.encodestring(unsubscribe_url.encode()).decode())
-
-	if email.expose_recipients == "header":
-		pass
-	else:
-		if email.expose_recipients == "footer":
-			if isinstance(email.show_as_cc, string_types):
-				email.show_as_cc = email.show_as_cc.split(",")
-			email_sent_to = [r.recipient for r in recipients_list]
-			email_sent_cc = ", ".join([e for e in email_sent_to if e in email.show_as_cc])
-			email_sent_to = ", ".join([e for e in email_sent_to if e not in email.show_as_cc])
-
-			if email_sent_cc:
-				email_sent_message = _("This email was sent to {0} and copied to {1}").format(email_sent_to,email_sent_cc)
-			else:
-				email_sent_message = _("This email was sent to {0}").format(email_sent_to)
-			message = message.replace("<!--cc message-->", quopri.encodestring(email_sent_message.encode()).decode())
-
-		message = message.replace("<!--recipient-->", recipient)
-
-	message = (message and message.encode('utf8')) or ''
-	message = safe_decode(message)
-
-	if PY3:
-		from email.policy import SMTPUTF8
-		message = Parser(policy=SMTPUTF8).parsestr(message)
-	else:
-		message = Parser().parsestr(message)
-
-	if email.attachments:
-		# On-demand attachments
-
-		attachments = json.loads(email.attachments)
-
-		for attachment in attachments:
-			if attachment.get('fcontent'):
-				continue
-
-			fid = attachment.get("fid")
-			if fid:
-				_file = frappe.get_doc("File", fid)
-				fcontent = _file.get_content()
-				attachment.update({
-					'fname': _file.file_name,
-					'fcontent': fcontent,
-					'parent': message
-				})
-				attachment.pop("fid", None)
-				add_attachment(**attachment)
-
-			elif attachment.get("print_format_attachment") == 1:
-				attachment.pop("print_format_attachment", None)
-				print_format_file = frappe.attach_print(**attachment)
-				print_format_file.update({"parent": message})
-				add_attachment(**print_format_file)
-
-	return safe_encode(message.as_string())
 
 def clear_outbox(days=None):
 	"""Remove low priority older than 31 days in Outbox or configured in Log Settings.

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -7,7 +7,8 @@ import sys
 from six.moves import html_parser as HTMLParser
 import smtplib, quopri, json
 from frappe import msgprint, _, safe_decode, safe_encode, enqueue
-from frappe.email.smtp import SMTPServer, get_outgoing_email_account
+from frappe.email.smtp import SMTPServer
+from frappe.email.doctype.email_account.email_account import EmailAccount
 from frappe.email.email_body import get_email, get_formatted_html, add_attachment
 from frappe.utils.verified_command import get_signed_params, verify_request
 from html2text import html2text
@@ -73,9 +74,11 @@ def send(recipients=None, sender=None, subject=None, message=None, text_content=
 	if isinstance(send_after, int):
 		send_after = add_days(nowdate(), send_after)
 
-	email_account = get_outgoing_email_account(True, append_to=reference_doctype, sender=sender)
+	email_account = EmailAccount.find_outgoing(
+		match_by_doctype=reference_doctype, match_by_email=sender, _raise_error=True)
+
 	if not sender or sender == "Administrator":
-		sender = email_account.default_sender
+		sender = email_account.email_id
 
 	if not text_content:
 		try:
@@ -516,7 +519,7 @@ def prepare_message(email, recipient, recipients_list):
 		return ""
 
 	# Parse "Email Account" from "Email Sender"
-	email_account = get_outgoing_email_account(raise_exception_not_set=False, sender=email.sender)
+	email_account = EmailAccount.find_outgoing(match_by_email=email.sender)
 	if frappe.conf.use_ssl and email_account.track_email_status:
 		# Using SSL => Publically available domain => Email Read Reciept Possible
 		message = message.replace("<!--email open check-->", quopri.encodestring('<img src="https://{}/api/method/frappe.core.doctype.communication.email.mark_email_as_seen?name={}"/>'.format(frappe.local.site, email.communication).encode()).decode())

--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -34,126 +34,6 @@ def send(email, append_to=None, retry=1):
 
 	_send(retry)
 
-def get_outgoing_email_account(raise_exception_not_set=True, append_to=None, sender=None):
-	"""Returns outgoing email account based on `append_to` or the default
-		outgoing account. If default outgoing account is not found, it will
-		try getting settings from `site_config.json`."""
-
-	sender_email_id = None
-	_email_account = None
-
-	if sender:
-		sender_email_id = parse_addr(sender)[1]
-
-	if not getattr(frappe.local, "outgoing_email_account", None):
-		frappe.local.outgoing_email_account = {}
-
-	if not (frappe.local.outgoing_email_account.get(append_to)
-		or frappe.local.outgoing_email_account.get(sender_email_id)
-		or frappe.local.outgoing_email_account.get("default")):
-		email_account = None
-
-		if sender_email_id:
-			# check if the sender has an email account with enable_outgoing
-			email_account = _get_email_account({"enable_outgoing": 1,
-					"email_id": sender_email_id})
-
-		if not email_account and append_to:
-			# append_to is only valid when enable_incoming is checked
-			email_accounts = frappe.db.get_values("Email Account", {
-				"enable_outgoing": 1,
-				"enable_incoming": 1,
-				"append_to": append_to,
-			}, cache=True)
-
-			if email_accounts:
-				_email_account = email_accounts[0]
-
-			else:
-				email_account = _get_email_account({
-					"enable_outgoing": 1,
-					"enable_incoming": 1,
-					"append_to": append_to
-				})
-
-		if not email_account:
-			# sender don't have the outging email account
-			sender_email_id = None
-			email_account = get_default_outgoing_email_account(raise_exception_not_set=raise_exception_not_set)
-
-		if not email_account and _email_account:
-			# if default email account is not configured then setup first email account based on append to
-			email_account = _email_account
-
-		if not email_account and raise_exception_not_set and cint(frappe.db.get_single_value('System Settings', 'setup_complete')):
-			frappe.throw(_("Please setup default Email Account from Setup > Email > Email Account"),
-				frappe.OutgoingEmailError)
-
-		if email_account:
-			if email_account.enable_outgoing and not getattr(email_account, 'from_site_config', False):
-				raise_exception = True
-				if email_account.smtp_server in ['localhost','127.0.0.1'] or email_account.no_smtp_authentication:
-					raise_exception = False
-				email_account.password = email_account.get_password(raise_exception=raise_exception)
-			email_account.default_sender = email.utils.formataddr((email_account.name, email_account.get("email_id")))
-
-		frappe.local.outgoing_email_account[append_to or sender_email_id or "default"] = email_account
-
-	return frappe.local.outgoing_email_account.get(append_to) \
-		or frappe.local.outgoing_email_account.get(sender_email_id) \
-		or frappe.local.outgoing_email_account.get("default")
-
-def get_default_outgoing_email_account(raise_exception_not_set=True):
-	'''conf should be like:
-		{
-		 "mail_server": "smtp.example.com",
-		 "mail_port": 587,
-		 "use_tls": 1,
-		 "mail_login": "emails@example.com",
-		 "mail_password": "Super.Secret.Password",
-		 "auto_email_id": "emails@example.com",
-		 "email_sender_name": "Example Notifications",
-		 "always_use_account_email_id_as_sender": 0,
-		 "always_use_account_name_as_sender_name": 0
-		}
-	'''
-	email_account = _get_email_account({"enable_outgoing": 1, "default_outgoing": 1})
-	if email_account:
-		email_account.password = email_account.get_password(raise_exception=False)
-
-	if not email_account and frappe.conf.get("mail_server"):
-		# from site_config.json
-		email_account = frappe.new_doc("Email Account")
-		email_account.update({
-			"smtp_server": frappe.conf.get("mail_server"),
-			"smtp_port": frappe.conf.get("mail_port"),
-
-			# legacy: use_ssl was used in site_config instead of use_tls, but meant the same thing
-			"use_tls": cint(frappe.conf.get("use_tls") or 0) or cint(frappe.conf.get("use_ssl") or 0),
-			"login_id": frappe.conf.get("mail_login"),
-			"email_id": frappe.conf.get("auto_email_id") or frappe.conf.get("mail_login") or 'notifications@example.com',
-			"password": frappe.conf.get("mail_password"),
-			"always_use_account_email_id_as_sender": frappe.conf.get("always_use_account_email_id_as_sender", 0),
-			"always_use_account_name_as_sender_name": frappe.conf.get("always_use_account_name_as_sender_name", 0)
-		})
-		email_account.from_site_config = True
-		email_account.name = frappe.conf.get("email_sender_name") or "Frappe"
-
-	if not email_account and not raise_exception_not_set:
-		return None
-
-	if frappe.are_emails_muted():
-		# create a stub
-		email_account = frappe.new_doc("Email Account")
-		email_account.update({
-			"email_id": "notifications@example.com"
-		})
-
-	return email_account
-
-def _get_email_account(filters):
-	name = frappe.db.get_value("Email Account", filters)
-	return frappe.get_doc("Email Account", name) if name else None
 
 class SMTPServer:
 	def __init__(self, login=None, password=None, server=None, port=None, use_tls=None, use_ssl=None, append_to=None):
@@ -176,7 +56,8 @@ class SMTPServer:
 			self.setup_email_account(append_to)
 
 	def setup_email_account(self, append_to=None, sender=None):
-		self.email_account = get_outgoing_email_account(raise_exception_not_set=False, append_to=append_to, sender=sender)
+		from frappe.email.doctype.email_account.email_account import EmailAccount
+		self.email_account = EmailAccount.find_outgoing(match_by_doctype=append_to, match_by_email=sender)
 		if self.email_account:
 			self.server = self.email_account.smtp_server
 			self.login = (getattr(self.email_account, "login_id", None) or self.email_account.email_id)

--- a/frappe/email/test_smtp.py
+++ b/frappe/email/test_smtp.py
@@ -4,7 +4,7 @@
 import unittest
 import frappe
 from frappe.email.smtp import SMTPServer
-from frappe.email.smtp import get_outgoing_email_account
+from frappe.email.doctype.email_account.email_account import EmailAccount
 
 class TestSMTP(unittest.TestCase):
 	def test_smtp_ssl_session(self):
@@ -34,12 +34,12 @@ class TestSMTP(unittest.TestCase):
 		frappe.local.outgoing_email_account = {}
 		# lowest preference given to email account with default incoming enabled
 		create_email_account(email_id="default_outgoing_enabled@gmail.com", password="***", enable_outgoing = 1, default_outgoing=1)
-		self.assertEqual(get_outgoing_email_account().email_id, "default_outgoing_enabled@gmail.com")
+		self.assertEqual(EmailAccount.find_outgoing().email_id, "default_outgoing_enabled@gmail.com")
 
 		frappe.local.outgoing_email_account = {}
 		# highest preference given to email account with append_to matching
 		create_email_account(email_id="append_to@gmail.com", password="***", enable_outgoing = 1, default_outgoing=1, append_to="Blog Post")
-		self.assertEqual(get_outgoing_email_account(append_to="Blog Post").email_id, "append_to@gmail.com")
+		self.assertEqual(EmailAccount.find_outgoing(match_by_doctype="Blog Post").email_id, "append_to@gmail.com")
 
 		# add back the mail_server
 		frappe.conf['mail_server'] = mail_server

--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -4,12 +4,14 @@
 
 from __future__ import unicode_literals
 
-import frappe
-from frappe.utils import cstr, encode
 import os
 import sys
-import inspect
 import traceback
+import functools
+
+import frappe
+from frappe.utils import cstr, encode
+import inspect
 import linecache
 import pydoc
 import cgitb
@@ -190,3 +192,34 @@ def clear_old_snapshots():
 
 def get_error_snapshot_path():
 	return frappe.get_site_path('error-snapshots')
+
+def get_default_args(func):
+	"""Get default arguments of a function from its signature.
+	"""
+	signature = inspect.signature(func)
+	return {k: v.default
+		for k, v in signature.parameters.items() if v.default is not inspect.Parameter.empty}
+
+def raise_error_on_no_output(error_message, error_type=None):
+	"""Decorate any function to throw error incase of missing output.
+
+	>>> @raise_error_on_no_output("Ingradients missing")
+	... def get_indradients(_raise_error=1): return
+	...
+	>>> get_indradients()
+	`Exception Name`: Ingradients missing
+	"""
+	def decorator_raise_error_on_no_output(func):
+		@functools.wraps(func)
+		def wrapper_raise_error_on_no_output(*args, **kwargs):
+			response = func(*args, **kwargs)
+
+			default_kwargs = get_default_args(func)
+			default_raise_error = default_kwargs.get('_raise_error')
+			raise_error = kwargs.get('_raise_error') if '_raise_error' in kwargs else default_raise_error
+
+			if (not response) and raise_error:
+				frappe.throw(error_message, error_type or Exception)
+			return response
+		return wrapper_raise_error_on_no_output
+	return decorator_raise_error_on_no_output


### PR DESCRIPTION
- [X] send mail utility works independently. Required input is only email queue record.
  Readable [10 liner Queue.send function](https://github.com/leela/frappe/blob/email-refactoring-2/frappe/email/doctype/email_queue/email_queue.py#L90) replaces almost 200 line functionality of the same.
- [ ] Tests and fixes